### PR TITLE
feat: Install lozen from GH in CI-related process

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ""
-      GITHUB_TOKEN: ${{secrets.LOZEN_TOKEN}}
       R_KEEP_PKG_SOURCE: yes
     steps:
       - uses: actions/checkout@v3

--- a/R/create_deploy_ci_stage.R
+++ b/R/create_deploy_ci_stage.R
@@ -73,7 +73,7 @@ create_deploy_ci_stage <- function(image,
         "mkdir -p $R_LIBS_USER",
         # Install git2r and pak
         "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-        "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", auth_token = Sys.getenv(\"GITHUB_TOKEN\"), build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+        "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
         le_call
       )
     )

--- a/R/with_gitlab_project.R
+++ b/R/with_gitlab_project.R
@@ -78,7 +78,7 @@ with_gitlab_project <- function(gitlab_url = Sys.getenv("GITLAB_URL", unset = "h
   
   # Create env var into gitlab project
   
-  lapply(c("CONNECT_TOKEN","CONNECT_URL", "CONNECT_USER", "GITHUB_TOKEN"), function(x){
+  lapply(c("CONNECT_TOKEN","CONNECT_URL", "CONNECT_USER"), function(x){
        get_or_create_var_env_gitlab(
          project_id,
          x,

--- a/dev/flat_helper_testthat.Rmd
+++ b/dev/flat_helper_testthat.Rmd
@@ -83,7 +83,7 @@ with_gitlab_project <- function(gitlab_url = Sys.getenv("GITLAB_URL", unset = "h
   
   # Create env var into gitlab project
   
-  lapply(c("CONNECT_TOKEN","CONNECT_URL", "CONNECT_USER", "GITHUB_TOKEN"), function(x){
+  lapply(c("CONNECT_TOKEN","CONNECT_URL", "CONNECT_USER"), function(x){
        get_or_create_var_env_gitlab(
          project_id,
          x,

--- a/dev/flat_init_gitlab_ci.Rmd
+++ b/dev/flat_init_gitlab_ci.Rmd
@@ -250,7 +250,7 @@ test_that("read_ci works", {
         script = list(
           "echo \"Library path for packages :\" R_LIBS_USER",
           "mkdir -p R_LIBS_USER", "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-          "Rscript -e 'options(remotes.git_credentials = git2r::cred_user_pass(\"gitlab-ci-token\", Sys.getenv(\"CI_JOB_TOKEN\")));remotes::install_git(\"https://forge.thinkr.fr/thinkr/thinkrverse/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+          "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
           "Rscript -e 'lozen::deploy_connect_shiny(connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
         )
       )
@@ -405,7 +405,7 @@ test_that("combine_ci works", {
         script = c(
           "echo \"Library path for packages :\" R_LIBS_USER",
           "mkdir -p R_LIBS_USER", "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-          "Rscript -e 'options(remotes.git_credentials = git2r::cred_user_pass(\"gitlab-ci-token\", Sys.getenv(\"CI_JOB_TOKEN\")));remotes::install_git(\"https://forge.thinkr.fr/thinkr/thinkrverse/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+          "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
           "Rscript -e 'lozen::deploy_connect_shiny(connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
         )
       )
@@ -608,7 +608,7 @@ create_deploy_ci_stage <- function(image,
         "mkdir -p $R_LIBS_USER",
         # Install git2r and pak
         "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-        "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", auth_token = Sys.getenv(\"GITHUB_TOKEN\"), build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+        "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
         le_call
       )
     )

--- a/inst/yaml/.gitlab-ci-shiny.yml
+++ b/inst/yaml/.gitlab-ci-shiny.yml
@@ -14,9 +14,7 @@ deploying:
   - mkdir -p R_LIBS_USER
   - Rscript -e 'install.packages(c("git2r"));install.packages("gitlabr", repos = c("https://thinkr-open.r-universe.dev",
     "https://cloud.r-project.org"))'
-  - Rscript -e 'options(remotes.git_credentials = git2r::cred_user_pass("gitlab-ci-token",
-    Sys.getenv("CI_JOB_TOKEN")));remotes::install_git("https://forge.thinkr.fr/thinkr/thinkrverse/lozen",
-    build_vignettes = FALSE, ref = Sys.getenv("LOZEN_BRANCH", unset = "main"))'
+  - Rscript -e 'remotes::install_github("thinkr-open/lozen", build_vignettes = FALSE, ref = Sys.getenv("LOZEN_BRANCH", unset = "main"))'
   - Rscript -e 'lozen::deploy_connect_shiny(connect_url = Sys.getenv("CONNECT_URL"),connect_user
     = Sys.getenv("CONNECT_USER"),connect_api_token = Sys.getenv("CONNECT_TOKEN"),app_name
     = Sys.getenv("APP_NAME", unset = Sys.getenv("CI_PROJECT_NAME")))'

--- a/tests/testthat/test-combine_ci.R
+++ b/tests/testthat/test-combine_ci.R
@@ -98,7 +98,7 @@ test_that("combine_ci works", {
         script = c(
           "echo \"Library path for packages :\" R_LIBS_USER",
           "mkdir -p R_LIBS_USER", "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-          "Rscript -e 'options(remotes.git_credentials = git2r::cred_user_pass(\"gitlab-ci-token\", Sys.getenv(\"CI_JOB_TOKEN\")));remotes::install_git(\"https://forge.thinkr.fr/thinkr/thinkrverse/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+          "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
           "Rscript -e 'lozen::deploy_connect_shiny(connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
         )
       )

--- a/tests/testthat/test-read_ci.R
+++ b/tests/testthat/test-read_ci.R
@@ -18,7 +18,7 @@ test_that("read_ci works", {
         script = list(
           "echo \"Library path for packages :\" R_LIBS_USER",
           "mkdir -p R_LIBS_USER", "Rscript -e 'install.packages(c(\"git2r\"));install.packages(\"gitlabr\", repos = c(\"https://thinkr-open.r-universe.dev\", \"https://cloud.r-project.org\"))'",
-          "Rscript -e 'options(remotes.git_credentials = git2r::cred_user_pass(\"gitlab-ci-token\", Sys.getenv(\"CI_JOB_TOKEN\")));remotes::install_git(\"https://forge.thinkr.fr/thinkr/thinkrverse/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
+          "Rscript -e 'remotes::install_github(\"thinkr-open/lozen\", build_vignettes = FALSE, ref = Sys.getenv(\"LOZEN_BRANCH\", unset = \"main\"))'",
           "Rscript -e 'lozen::deploy_connect_shiny(connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
         )
       )


### PR DESCRIPTION
tags: feat, ci

Why?

- lozen was previously installed from forge.thinkr.fr

What?

-

Issues

issue #9 #4