### PR TITLE
fix: use renv in gitlab ci connect deploy job

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lozen
 Title: Management tools for missions
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Authors@R: c(
     person("Sébastien", "Rochette", , "sebastien@thinkr.fr", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1565-9313")),
@@ -74,9 +74,9 @@ Remotes:
     ThinkR-open/gitlabr,
     ThinkR-open/testdown,
     ThinkR-open/thinkrtemplate
-Config/fusen/version: 0.5.1
+Config/fusen/version: 0.5.2
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lozen (development)
 
+# lozen 1.3.9001
+
+- Use {renv} in gitlab ci connect deploy job
+
 # lozen 1.3.0
 
 ## Major

--- a/R/create_deploy_ci_stage.R
+++ b/R/create_deploy_ci_stage.R
@@ -24,7 +24,7 @@ create_deploy_ci_stage <- function(
   stopifnot("deploy_function exist" = length(getFromNamespace(x = deploy_function, "lozen")) > 0)
 
   le_call <- glue::glue(
-    "Rscript -e 'options(rsconnect.packrat = TRUE); lozen::{deploy_function}(forceUpdate=TRUE, connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
+    "Rscript -e 'lozen::{deploy_function}(forceUpdate=TRUE, connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
   )
 
   # Create list of Connect CI parameters

--- a/dev/flat_init_gitlab_ci.Rmd
+++ b/dev/flat_init_gitlab_ci.Rmd
@@ -728,13 +728,15 @@ create_deploy_ci_stage <- function(
   stopifnot("deploy_function exist" = length(getFromNamespace(x = deploy_function, "lozen")) > 0)
 
   le_call <- glue::glue(
-    "Rscript -e 'options(rsconnect.packrat = TRUE); lozen::{deploy_function}(forceUpdate=TRUE, connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
+    "Rscript -e 'lozen::{deploy_function}(forceUpdate=TRUE, connect_url = Sys.getenv(\"CONNECT_URL\"),connect_user = Sys.getenv(\"CONNECT_USER\"),connect_api_token = Sys.getenv(\"CONNECT_TOKEN\"),app_name = Sys.getenv(\"APP_NAME\", unset = Sys.getenv(\"CI_PROJECT_NAME\")))'"
   )
 
   # Create list of Connect CI parameters
   connect_ci_list <- list(
     image = image,
     variables = list(
+      GIT_DEPTH = 10L,
+      REPO_NAME = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
       R_LIBS_USER = "ci/lib"
     ),
     cache = list(

--- a/man/deploy_connect_bookdown.Rd
+++ b/man/deploy_connect_bookdown.Rd
@@ -33,9 +33,14 @@ deploy_connect_bookdown(
 
 \item{file_to_ignore_regex}{Regex to use to ignore files}
 
-\item{forceUpdate}{If \code{TRUE}, update any previously-deployed app without
-asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
-\code{getOption("rsconnect.force.update.apps", FALSE)}.}
+\item{forceUpdate}{What should happen if there's no deployment record for
+the app, but there's an app with the same name on the server? If \code{TRUE},
+will always update the previously-deployed app. If \code{FALSE}, will ask
+the user what to do, or fail if not in an interactive context.
+
+Defaults to \code{TRUE} when called automatically by the IDE, and \code{FALSE}
+otherwise. You can override the default by setting option
+\code{rsconnect.force.update.apps}.}
 
 \item{lint}{Lint the project before initiating deployment, to identify
 potentially problematic code?}

--- a/man/deploy_connect_pkgdown.Rd
+++ b/man/deploy_connect_pkgdown.Rd
@@ -39,9 +39,14 @@ file.path(getwd(), ".")   )}
 
 \item{file_to_ignore_regex}{Regex to use to ignore files}
 
-\item{forceUpdate}{If \code{TRUE}, update any previously-deployed app without
-asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
-\code{getOption("rsconnect.force.update.apps", FALSE)}.}
+\item{forceUpdate}{What should happen if there's no deployment record for
+the app, but there's an app with the same name on the server? If \code{TRUE},
+will always update the previously-deployed app. If \code{FALSE}, will ask
+the user what to do, or fail if not in an interactive context.
+
+Defaults to \code{TRUE} when called automatically by the IDE, and \code{FALSE}
+otherwise. You can override the default by setting option
+\code{rsconnect.force.update.apps}.}
 
 \item{lint}{Lint the project before initiating deployment, to identify
 potentially problematic code?}

--- a/man/deploy_connect_shiny.Rd
+++ b/man/deploy_connect_shiny.Rd
@@ -33,9 +33,14 @@ deploy_connect_shiny(
 
 \item{file_to_ignore_regex}{Regex to use to ignore files}
 
-\item{forceUpdate}{If \code{TRUE}, update any previously-deployed app without
-asking. If \code{FALSE}, ask to update. If unset, defaults to the value of
-\code{getOption("rsconnect.force.update.apps", FALSE)}.}
+\item{forceUpdate}{What should happen if there's no deployment record for
+the app, but there's an app with the same name on the server? If \code{TRUE},
+will always update the previously-deployed app. If \code{FALSE}, will ask
+the user what to do, or fail if not in an interactive context.
+
+Defaults to \code{TRUE} when called automatically by the IDE, and \code{FALSE}
+otherwise. You can override the default by setting option
+\code{rsconnect.force.update.apps}.}
 
 \item{lint}{Lint the project before initiating deployment, to identify
 potentially problematic code?}

--- a/tests/testthat/test-use_gitlab_ci.R
+++ b/tests/testthat/test-use_gitlab_ci.R
@@ -27,28 +27,27 @@ test_that("init_gitlab_ci works for bookdown and  bookdown_output_format = lozen
   # Test on Gitlab : Create a bookdown and test the CI
   if (Sys.getenv("ALLOW_CI_TESTS_ON_GITLAB", unset = "FALSE") == "TRUE") {
     # Pour un template CI "bookdown"
-    output_bookdown <- with_gitlab_project(
-      gitlab_url = Sys.getenv("GITLAB_URL", unset = "https://gitlab.com"),
-      namespace_id = NULL,
-      private_token = Sys.getenv("GITLAB_TOKEN"),
-      project_name = "bookdown.test.project",
-      exp = {
-        lozen::create_r_project(
-          project_path = getwd(),
-          type = "book",
-          name_licence = "Bobo",
-          type_licence = usethis::use_mit_license
-        )
-        lozen::use_gitlab_ci(type = "bookdown", bookdown_output_format = "lozen::paged_template")
-      }
+  output_bookdown <- with_gitlab_project(
+  gitlab_url = Sys.getenv("GITLAB_URL", unset = "https://gitlab.com"),
+  namespace_id = NULL,
+  private_token = Sys.getenv("GITLAB_TOKEN"),
+  project_name = "bookdown.test.project",
+  exp = {
+    lozen::create_r_project(
+      project_path =  getwd(),
+      type = "book", name_licence = "Bobo", type_licence = usethis::use_mit_license    
     )
+    lozen::use_gitlab_ci(type = "bookdown", bookdown_output_format = "lozen::paged_template")
+  }
+)
 
     expect_equal(
       object = output_bookdown$status,
       expected = "success"
     )
   }
-})
+
+ })
 
 test_that("init_gitlab_ci works for bookdown and  bookdown_output_format = lozen::bs4_book_template", {
   # TODO - Remove ; allow test to pass on CI
@@ -57,28 +56,27 @@ test_that("init_gitlab_ci works for bookdown and  bookdown_output_format = lozen
   # Test on Gitlab : Create a bookdown and test the CI
   if (Sys.getenv("ALLOW_CI_TESTS_ON_GITLAB", unset = "FALSE") == "TRUE") {
     # Pour un template CI "bookdown"
-    output_bookdown <- with_gitlab_project(
-      gitlab_url = Sys.getenv("GITLAB_URL", unset = "https://gitlab.com"),
-      namespace_id = NULL,
-      private_token = Sys.getenv("GITLAB_TOKEN"),
-      project_name = "bookdown.test.project",
-      exp = {
-        lozen::create_r_project(
-          project_path = getwd(),
-          type = "book",
-          name_licence = "Bobo",
-          type_licence = usethis::use_mit_license
-        )
-        lozen::use_gitlab_ci(type = "bookdown", bookdown_output_format = "lozen::bs4_book_template")
-      }
+  output_bookdown <- with_gitlab_project(
+  gitlab_url = Sys.getenv("GITLAB_URL", unset = "https://gitlab.com"),
+  namespace_id = NULL,
+  private_token = Sys.getenv("GITLAB_TOKEN"),
+  project_name = "bookdown.test.project",
+  exp = {
+    lozen::create_r_project(
+      project_path =  getwd(),
+      type = "book", name_licence = "Bobo", type_licence = usethis::use_mit_license    
     )
+    lozen::use_gitlab_ci(type = "bookdown", bookdown_output_format = "lozen::bs4_book_template")
+  }
+)
 
     expect_equal(
       object = output_bookdown$status,
       expected = "success"
     )
   }
-})
+
+ })
 
 
 test_that("init_gitlab_ci works for shiny", {


### PR DESCRIPTION
Why :

- New version of connect successfully use renv to deploy apps. The downgrade to packrat is not necessary anymore.

How :

- Remove rsconnect.packrat option from deploy instruction in gitlab-ci.yml