### PR TITLE
docs: clarify Hits/Line example in coverage report

### DIFF
--- a/inst/package/codecoverage_explanation.md
+++ b/inst/package/codecoverage_explanation.md
@@ -7,7 +7,7 @@
 - Covered = Number of lines covered by a test
 - Missed = Number of lines not covered by a test
 - Hits/Line = Corresponds to the average number of times specific lines are tested in the file.
-    + In other words, if I have an 11-lines file where (1) the first 6 lines are tested 4 times, (2) the seventh is tested 1 time, (3) the last 4 are tested 10 times. The calculation is then: ((6 * 4) + 1 + (10 * 4))/11 = 6. This gives the average number of times a line is tested, here 6. 
+    + In other words, if I have an 11-lines file where (1) the first 6 lines are tested 4 times, (2) the seventh is tested 1 time, (3) the last 4 are tested 10 times. The calculation is then: ((6 * 4) + (1 * 1) + (4 * 10))/11 = 6. This gives the average number of times a line is tested, here 6. 
 - Coverage = corresponds to the percentage of lines covered by a test. Calculation: Covered / Relevant * 100, number of lines covered by a test divided by the number of lines requiring testing.
 - If we go into detail by file, the color code is as follows:
     - green line = line tested by at least one test (the x? corresponds to the number of times the line is tested)


### PR DESCRIPTION
Thanks for creating the description of coverage report! I’ve been using it for our R package, and it’s been really helpful for onboarding team members who are new to code coverage.

One small suggestion from one of our team members (addressed in this PR): to make the “Hits/Line” section a bit clearer, the multiplication order could be flipped so it better matches the description. 