### PR TITLE
ci: bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ""
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ""
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
## Summary
Bump deprecated GitHub Actions to currently-supported majors. No behavioural change intended.

## Bumps applied (where present)
- `actions/checkout` v1/v2/v3 → v4
- `actions/cache` v1/v2/v3 → v4
- `actions/upload-artifact` v1/v2/v3 → v4
- `actions/download-artifact` v1.x/v2/v3 → v4
- `r-lib/actions/*` @v1 → @v2
- `r-lib/actions/setup-tinytex` @master → @v2

## Test plan
- [ ] CI runs green on this PR