### PR TITLE
Drop deprecated repo_name passed to gitlabr::use_gitlab_ci()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,4 +79,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3

--- a/R/use_gitlab_ci.R
+++ b/R/use_gitlab_ci.R
@@ -5,10 +5,14 @@
 #' Set gitlab continuous integration
 #'
 #' @param image Docker image used as basis. See \url{https://github.com/rocker-org/rocker}
+#' @param repo_name Deprecated. Kept for backward compatibility but ignored: as of
+#'   gitlabr 2.1, the CRAN mirror is set via the `REPO_NAME` GitLab CI/CD variable
+#'   (see \code{inst/gitlab-ci/bookdown-production.yml} in gitlabr) rather than as
+#'   an argument to `gitlabr::use_gitlab_ci()`.
 #' @param project_path Path of the project to add CI in.
 #' @param bookdown_output_format If type="bookdown" it corresponds to the function used to output the bookdown
 #' @inheritParams gitlabr::use_gitlab_ci
-#' @importFrom cli cli_alert_info
+#' @importFrom cli cli_alert_info cli_alert_warning
 #'
 #' @details See \code{\link[gitlabr]{use_gitlab_ci}}
 #'
@@ -21,7 +25,6 @@
 #' withr::with_tempdir({
 #'   use_gitlab_ci(
 #'     image = "rocker/verse",
-#'     repo_name = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
 #'     type = "check-coverage-pkgdown"
 #'   )
 #' })
@@ -33,6 +36,12 @@ use_gitlab_ci <- function(
   bookdown_output_format = c("lozen::paged_template", "lozen::bs4_book_template"),
   overwrite = TRUE
     ) {
+  if (!missing(repo_name)) {
+    cli_alert_warning(
+      "Argument `repo_name` is deprecated and ignored: gitlabr 2.1+ takes the CRAN mirror from the REPO_NAME CI/CD variable, not from a function argument."
+    )
+  }
+
   ci_file <- file.path(project_path, ".gitlab-ci.yml")
 
   if (
@@ -62,7 +71,6 @@ use_gitlab_ci <- function(
 
   gitlabr::use_gitlab_ci(
     image = image,
-    repo_name = repo_name,
     path = ci_file,
     type = type
   )

--- a/dev/flat_init_gitlab_ci.Rmd
+++ b/dev/flat_init_gitlab_ci.Rmd
@@ -24,10 +24,14 @@ pkgload::load_all(export_all = FALSE)
 #' Set gitlab continuous integration
 #'
 #' @param image Docker image used as basis. See \url{https://github.com/rocker-org/rocker}
+#' @param repo_name Deprecated. Kept for backward compatibility but ignored: as of
+#'   gitlabr 2.1, the CRAN mirror is set via the `REPO_NAME` GitLab CI/CD variable
+#'   (see \code{inst/gitlab-ci/bookdown-production.yml} in gitlabr) rather than as
+#'   an argument to `gitlabr::use_gitlab_ci()`.
 #' @param project_path Path of the project to add CI in.
 #' @param bookdown_output_format If type="bookdown" it corresponds to the function used to output the bookdown
 #' @inheritParams gitlabr::use_gitlab_ci
-#' @importFrom cli cli_alert_info
+#' @importFrom cli cli_alert_info cli_alert_warning
 #'
 #' @details See \code{\link[gitlabr]{use_gitlab_ci}}
 #'
@@ -40,6 +44,12 @@ use_gitlab_ci <- function(
   bookdown_output_format = c("lozen::paged_template", "lozen::bs4_book_template"),
   overwrite = TRUE
     ) {
+  if (!missing(repo_name)) {
+    cli_alert_warning(
+      "Argument `repo_name` is deprecated and ignored: gitlabr 2.1+ takes the CRAN mirror from the REPO_NAME CI/CD variable, not from a function argument."
+    )
+  }
+
   ci_file <- file.path(project_path, ".gitlab-ci.yml")
 
   if (
@@ -69,7 +79,6 @@ use_gitlab_ci <- function(
 
   gitlabr::use_gitlab_ci(
     image = image,
-    repo_name = repo_name,
     path = ci_file,
     type = type
   )
@@ -150,7 +159,6 @@ withr::with_tempdir({
 withr::with_tempdir({
   use_gitlab_ci(
     image = "rocker/verse",
-    repo_name = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
     type = "check-coverage-pkgdown"
   )
 })

--- a/man/use_gitlab_ci.Rd
+++ b/man/use_gitlab_ci.Rd
@@ -16,7 +16,10 @@ use_gitlab_ci(
 \arguments{
 \item{image}{Docker image used as basis. See \url{https://github.com/rocker-org/rocker}}
 
-\item{repo_name}{REPO_NAME environment variable for R CRAN mirror used}
+\item{repo_name}{Deprecated. Kept for backward compatibility but ignored: as of
+gitlabr 2.1, the CRAN mirror is set via the \code{REPO_NAME} GitLab CI/CD variable
+(see \code{inst/gitlab-ci/bookdown-production.yml} in gitlabr) rather than as
+an argument to \code{gitlabr::use_gitlab_ci()}.}
 
 \item{project_path}{Path of the project to add CI in.}
 
@@ -40,7 +43,6 @@ withr::with_tempdir({
 withr::with_tempdir({
   use_gitlab_ci(
     image = "rocker/verse",
-    repo_name = "https://packagemanager.rstudio.com/all/__linux__/focal/latest",
     type = "check-coverage-pkgdown"
   )
 })


### PR DESCRIPTION
## Contexte

`R-CMD-check` et `test-coverage` étaient rouges sur `main` depuis 2025-10-23 :

\`\`\`
Error in \`gitlabr::use_gitlab_ci(image = image, repo_name = repo_name, path = ci_file, type = type)\`:
  unused argument (repo_name = repo_name)
\`\`\`

## Cause

`gitlabr` 2.1 a supprimé l'argument `repo_name`. Le mirror CRAN est désormais paramétré dans le template YAML via la variable CI/CD `REPO_NAME` (cf. \`inst/gitlab-ci/bookdown-production.yml\` chez gitlabr) plutôt qu'en argument de fonction.

## Fix

- Ne plus forwarder `repo_name` à \`gitlabr::use_gitlab_ci()\`.
- Garder l'argument côté lozen pour compatibilité ascendante avec les appelants existants, marqué deprecated dans la doc et avec un \`cli_alert_warning\` si fourni explicitement.
- Mêmes modifs côté flat fusen (\`dev/flat_init_gitlab_ci.Rmd\`) pour rester en phase.
- Bump RoxygenNote 7.3.1 → 7.3.3 (effet de bord du \`roxygenise()\`).

## Test

\`\`\`
> devtools::test(filter = \"use_gitlab_ci$|check_if_yaml_exists\")
[ FAIL 0 | WARN 0 | SKIP 5 | PASS 4 ]
\`\`\`

Les tests précédemment rouges (\`test-use_gitlab_ci.R:5:5\` et \`test-check_if_yaml_exists.R:5:5\`) passent. Les SKIPs sont des tests \`skip_on_ci()\` existants pour scénarios bookdown/golem qui demandent un GitLab réel.